### PR TITLE
add install.sh for sketchybar config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ success() { echo -e "${GREEN}✔ $1${RESET}"; }
 log "clone sketchybar-config repository..."
 CONFIG_DIR="$HOME/.config"
 rm -rf "$CONFIG_DIR/sketchybar"
-git clone --depth 1 https://www.github.com/Kcraft059/sketchybar-config "CONFIG_DIR/sketchybar"
+git clone --depth 1 https://github.com/Kcraft059/sketchybar-config "CONFIG_DIR/sketchybar"
 success "cloned sketchybar-config repository"
 
 log "Installing SketchyBar dependencies..."

--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,23 @@ mkdir -p "$(dirname "$output_path")"
 curl -fsSL -o "$output_path" "$font_url" || error "Failed to download dyn-icon_map.sh."
 success "Downloaded dyn-icon_map.sh → $output_path"
 
+### GitHub Notifications Setup
+read -rp "$(echo -e "${YELLOW}➤ Do you want to enable GitHub notifications in SketchyBar? (y/n): ${RESET}")" enable_github
+
+if [[ "$enable_github" =~ ^[Yy]$ ]]; then
+  read -rsp "$(echo -e "${YELLOW}➤ Please enter your Classic GitHub Token: ${RESET}")" github_token
+  echo
+  if [[ -n "$github_token" ]]; then
+    echo "$github_token" > "$HOME/.github_token"
+    chmod 600 "$HOME/.github_token"
+    success "GitHub token saved to ~/.github_token (permissions set to 600)."
+  else
+    error "No token entered. Skipping GitHub notifications setup."
+  fi
+else
+  log "Skipped GitHub notifications setup."
+fi
+
 ### Restart SketchyBar
 log "Restarting SketchyBar..."
 brew services restart sketchybar

--- a/install.sh
+++ b/install.sh
@@ -3,15 +3,21 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Colors
-GREEN="\033[0;32m"
-YELLOW="\033[1;33m"
-RED="\033[0;31m"
+
+spmt='\033[38;5;5;1m> \033[0m\033[48;5;0m' # >_
+sqes='\033[48;5;0;38;5;8m[\033[38;5;4m?\033[38;5;8m]\033[0m' # [?]
+scac='\033[48;5;0;38;5;8m[\033[38;5;1mx\033[38;5;8m]\033[0m' # [x]
+sexc='\033[48;5;0;38;5;8m[\033[38;5;2mo\033[38;5;8m]\033[0m' # [o]
+smak='\033[48;5;0;38;5;8m[\033[38;5;5m+\033[38;5;8m]\033[0m' # [+]
+swrn='\033[48;5;0;38;5;8m[\033[38;5;3m!\033[38;5;8m]\033[0m' # [!]
+syon='(\033[38;5;2;1my\033[38;5;0m/\033[38;5;1;1mn\033[0m)' # (y/n)
+
 RESET="\033[0m"
 
 # Logging helpers
-log()     { echo -e "${YELLOW}➤ $1${RESET}"; }
-success() { echo -e "${GREEN}✔ $1${RESET}"; }
-error()   { echo -e "${RED}✖ $1${RESET}" >&2; exit 1; }
+log()     { echo -e "${sexc} $1${RESET}"; }
+success() { echo -e "${smak} $1${RESET}"; }
+error()   { echo -e "${scac} $1${RESET}" >&2; exit 1; }
 
 # Ensure dependencies
 for cmd in git brew curl jq; do
@@ -50,10 +56,10 @@ curl -fsSL -o "$output_path" "$font_url" || error "Failed to download dyn-icon_m
 success "Downloaded dyn-icon_map.sh → $output_path"
 
 ### GitHub Notifications Setup
-read -rp "$(echo -e "${YELLOW}➤ Do you want to enable GitHub notifications in SketchyBar? (y/n): ${RESET}")" enable_github
+read -rp "$(echo -e "${sqes} Do you want to enable GitHub notifications in SketchyBar? ${syon}: ${RESET}")" enable_github
 
 if [[ "$enable_github" =~ ^[Yy]$ ]]; then
-  read -rsp "$(echo -e "${YELLOW}➤ Please enter your Classic GitHub Token: ${RESET}")" github_token
+  read -rsp "$(echo -e "${sqes} Please enter your Classic GitHub Token: ${RESET}")" github_token
   echo
   if [[ -n "$github_token" ]]; then
     echo "$github_token" > "$HOME/.github_token"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+GREEN="\033[0;32m"
+YELLOW="\033[1;33m"
+RESET="\033[0m"
+log() { echo -e "${YELLOW}➤ $1${RESET}"; }
+success() { echo -e "${GREEN}✔ $1${RESET}"; }
+
+log "clone sketchybar-config repository..."
+CONFIG_DIR="$HOME/.config"
+rm -rf "$CONFIG_DIR/sketchybar"
+git clone --depth 1 https://www.github.com/Kcraft059/sketchybar-config "CONFIG_DIR/sketchybar"
+success "cloned sketchybar-config repository"
+
+log "Installing SketchyBar dependencies..."
+brew tap FelixKratz/formulae
+brew install sketchybar media-control macmon image-magick
+brew install --cask sf-symbols font-sketchybar-app-font SF-Pro
+success "installed dependencies..."
+
+log "get latest icon map ..."
+latest_tag=$(curl -s https://api.github.com/repos/kvndrsslr/sketchybar-app-font/releases/latest | grep '"tag_name":' | cut -d '"' -f 4)
+font_url="https://github.com/kvndrsslr/sketchybar-app-font/releases/download/${latest_tag}/icon_map.sh"
+output_path="$CONFIG_DIR/sketchybar/dyn-icon_map.sh"
+rm -f "$output_path"
+mkdir -p "$(dirname "$output_path")"
+curl -L "$font_url" -o "$output_path"
+success "Downloaded dyn-icon_map.sh"
+
+brew services restart sketchybar
+sketchybar --reload
+success "SketchyBar loaded."

--- a/install.sh
+++ b/install.sh
@@ -11,12 +11,12 @@ success() { echo -e "${GREEN}✔ $1${RESET}"; }
 log "clone sketchybar-config repository..."
 CONFIG_DIR="$HOME/.config"
 rm -rf "$CONFIG_DIR/sketchybar"
-git clone --depth 1 https://github.com/Kcraft059/sketchybar-config "CONFIG_DIR/sketchybar"
+git clone --depth 1 https://github.com/Kcraft059/sketchybar-config "$CONFIG_DIR/sketchybar"
 success "cloned sketchybar-config repository"
 
 log "Installing SketchyBar dependencies..."
 brew tap FelixKratz/formulae
-brew install sketchybar media-control macmon image-magick
+brew install sketchybar media-control macmon imagemagick
 brew install --cask sf-symbols font-sketchybar-app-font SF-Pro
 success "installed dependencies..."
 

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ success "cloned sketchybar-config repository"
 log "Installing SketchyBar dependencies..."
 brew tap FelixKratz/formulae
 brew install sketchybar media-control macmon imagemagick
-brew install --cask sf-symbols font-sketchybar-app-font SF-Pro
+brew install --cask sf-symbols font-sketchybar-app-font font-sf-pro
 success "installed dependencies..."
 
 log "get latest icon map ..."

--- a/install.sh
+++ b/install.sh
@@ -2,33 +2,55 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# Colors
 GREEN="\033[0;32m"
 YELLOW="\033[1;33m"
+RED="\033[0;31m"
 RESET="\033[0m"
-log() { echo -e "${YELLOW}➤ $1${RESET}"; }
+
+# Logging helpers
+log()     { echo -e "${YELLOW}➤ $1${RESET}"; }
 success() { echo -e "${GREEN}✔ $1${RESET}"; }
+error()   { echo -e "${RED}✖ $1${RESET}" >&2; exit 1; }
 
-log "clone sketchybar-config repository..."
-CONFIG_DIR="$HOME/.config"
-rm -rf "$CONFIG_DIR/sketchybar"
-git clone --depth 1 https://github.com/Kcraft059/sketchybar-config "$CONFIG_DIR/sketchybar"
-success "cloned sketchybar-config repository"
+# Ensure dependencies
+for cmd in git brew curl jq; do
+  command -v "$cmd" >/dev/null 2>&1 || error "$cmd not found. Please install it first."
+done
 
+CONFIG_DIR="$HOME/.config/sketchybar"
+
+### Clone config
+log "Cloning sketchybar-config repository..."
+rm -rf "$CONFIG_DIR"
+git clone --depth 1 https://github.com/Kcraft059/sketchybar-config "$CONFIG_DIR"
+success "Cloned sketchybar-config repository."
+
+### Install dependencies
 log "Installing SketchyBar dependencies..."
 brew tap FelixKratz/formulae
-brew install sketchybar media-control macmon imagemagick
-brew install --cask sf-symbols font-sketchybar-app-font font-sf-pro
-success "installed dependencies..."
+brew install sketchybar media-control macmon imagemagick \
+  || error "Failed to install formulae."
+brew install --cask sf-symbols font-sketchybar-app-font font-sf-pro \
+  || error "Failed to install casks."
+success "Installed dependencies."
 
-log "get latest icon map ..."
-latest_tag=$(curl -s https://api.github.com/repos/kvndrsslr/sketchybar-app-font/releases/latest | grep '"tag_name":' | cut -d '"' -f 4)
+### Download latest icon map with jq
+log "Fetching latest icon map..."
+latest_tag=$(curl -fsSL https://api.github.com/repos/kvndrsslr/sketchybar-app-font/releases/latest \
+  | jq -r .tag_name)
+
+log "Latest release tag: $latest_tag"
+
 font_url="https://github.com/kvndrsslr/sketchybar-app-font/releases/download/${latest_tag}/icon_map.sh"
-output_path="$CONFIG_DIR/sketchybar/dyn-icon_map.sh"
-rm -f "$output_path"
-mkdir -p "$(dirname "$output_path")"
-curl -L "$font_url" -o "$output_path"
-success "Downloaded dyn-icon_map.sh"
+output_path="$CONFIG_DIR/dyn-icon_map.sh"
 
+mkdir -p "$(dirname "$output_path")"
+curl -fsSL -o "$output_path" "$font_url" || error "Failed to download dyn-icon_map.sh."
+success "Downloaded dyn-icon_map.sh → $output_path"
+
+### Restart SketchyBar
+log "Restarting SketchyBar..."
 brew services restart sketchybar
 sketchybar --reload
-success "SketchyBar loaded."
+success "SketchyBar loaded and reloaded."


### PR DESCRIPTION
this script will clone your sketchybar-config repo with `depth 1`, install lastest icon map and dependencies, you can edit README.md whatever you want but it should include:

Installation
```
bash -c "$(curl -fsSL https://raw.githubusercontent.com/Kcraft059/sketchybar-config/main/install.sh)"
```