### PR TITLE
Fix RealName getter statement

### DIFF
--- a/plugins/currentuser/script.sh
+++ b/plugins/currentuser/script.sh
@@ -2,5 +2,11 @@
 
 ### Get real name of current user
 
-RealName=$(dscl . -read /Users/"$(whoami)" RealName | awk 'NR>1 {sub(/^[[:space:]]*/, ""); print; exit}')
+RealName=$(dscl . -read /Users/"$(whoami)" RealName | awk '/RealName: / {gsub("RealName: ",""); print}')
+
+# If no RealName found, check for RealName at the next line (caused by spaces in the RealName)
+if [ -z $RealName ]; then 
+	RealName=$(dscl . -read /Users/"$(whoami)" RealName | awk 'NR>1 {sub(/^[[:space:]]*/, ""); print; exit}')
+fi
+
 sketchybar --set "$NAME" label="$RealName"


### PR DESCRIPTION
Was getting `@RealName:` instead of showing the actual name. As my name was on a new line after the header.

<img width="209" height="48" alt="image" src="https://github.com/user-attachments/assets/dfc07389-cc63-47be-aecf-7d7c928f5042" />
